### PR TITLE
The parameter `services` is passed for the `send_repository_dispatch_…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2025-02-20
+
+### Changed
+
+- The parameter `services` is passed for the `send_repository_dispatch_event` function as List[str] instead of a comma seperated list.
+
 ## [0.3.3] - 2025-02-19
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jeap_pipeline"
-version = "0.3.3"
+version = "0.3.4"
 authors = [
     { name="Laris Jacobs", email="laris.jacobs@bit.admin.ch" },
+    { name="Jose Alvarez Morales", email="jose.alvarezmorales@bit.admin.ch"}
 ]
 description = "A collection of Python modules and libraries for CI/CD pipelines in the jEAP context."
 readme = "README.md"

--- a/src/jeap_pipeline/github_dispatch_event.py
+++ b/src/jeap_pipeline/github_dispatch_event.py
@@ -1,10 +1,10 @@
 import os
 import requests
 import json
-from typing import Optional
+from typing import Optional, List
 
 
-def send_dispatch_event(organization: str, repository_name: str, stage: str, version: str, services: str) -> None:
+def send_dispatch_event(organization: str, repository_name: str, stage: str, version: str, services: List[str]) -> None:
     """
     Sends a GitHub Repository Dispatch Event to trigger workflows.
 
@@ -16,7 +16,7 @@ def send_dispatch_event(organization: str, repository_name: str, stage: str, ver
         repository_name (str): The name of the GitHub repository.
         stage (str): The deployment stage (e.g., dev, staging, prod).
         version (str): The version of the deployment.
-        services (str): A comma-separated list of services.
+        services List[str]: A comma-separated list of services.
 
     Returns:
         None
@@ -29,12 +29,11 @@ def send_dispatch_event(organization: str, repository_name: str, stage: str, ver
     if not github_token:
         raise EnvironmentError("GITHUB_TOKEN environment variable is not set")
 
-    services_list = services.split(',')
     payload = {
         "event_type": "new-version-published",
         "client_payload": {
             "stage": stage,
-            "services": services_list,
+            "services": services,
             "version": version
         }
     }

--- a/tests/test_github_dispatch_event.py
+++ b/tests/test_github_dispatch_event.py
@@ -15,7 +15,7 @@ class TestSendDispatchEvent(unittest.TestCase):
         mock_response.raise_for_status = MagicMock()
         mock_post.return_value = mock_response
 
-        send_dispatch_event('my-org', 'my-repo', 'dev', 'v1.0.0', 'service1,service2')
+        send_dispatch_event('my-org', 'my-repo', 'dev', 'v1.0.0', ['service1', 'service2'])
         mock_getenv.assert_called_once_with('GITHUB_TOKEN')
 
         expected_url = 'https://api.github.com/repos/my-org/my-repo/dispatches'


### PR DESCRIPTION
…event` function as List[str] instead of a comma seperated list.